### PR TITLE
Improve compatibility with recent Rust versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.idea/

--- a/README.md
+++ b/README.md
@@ -6,14 +6,30 @@
 
 Traits over atomic primitive integer types.
 
+## Example
+
+```rust
+fn incr<T: AtomicInt>(value: &T) -> Result<<T as AtomicInt>::Prim, <T as AtomicInt>::Prim> {
+    value.fetch_update(
+        Ordering::SeqCst,
+        Ordering::SeqCst,
+        |i| Some(if i == T::MAX { T::MIN } else { i + T::ONE })
+    )
+}
+
+let value = AtomicU8::new(255);
+assert_eq!(incr(&value), Ok(255));
+assert_eq!(incr(&value), Ok(0));
+```
+
 ## Notes
 
 * Enable feature `nightly` to get `as_mut_ptr` when you have a nightly compiler available.
-* Rust 1.45.0 or newer is required
+* Rust 1.45.0 or newer is required.
 
 ## Copyright and License
 
-    Copyright (c) 2020 James Laver, atomic_prim_traits contributors.
+    Copyright (c) 2020-2023 James Laver, atomic_prim_traits contributors.
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Traits over atomic primitive integer types.
 
 ## Notes
 
-* Enable feature `nightly` to get `min`, `max`, `fetch_update` and
-  `as_mut_ptr` when you have a nightly compiler available.
+* Enable feature `nightly` to get `as_mut_ptr` when you have a nightly compiler available.
+* Rust 1.45.0 or newer is required
 
 ## Copyright and License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,13 +92,6 @@ pub trait AtomicInt : Default + Send + Sync + RefUnwindSafe + UnwindSafe {
 
     fn swap(&self, val: <Self as AtomicInt>::Prim, order: Ordering) -> <Self as AtomicInt>::Prim;
 
-    fn compare_and_swap(
-        &self,
-        current: <Self as AtomicInt>::Prim,
-        new: <Self as AtomicInt>::Prim,
-        ordering: Ordering
-    ) -> <Self as AtomicInt>::Prim;
-
     fn compare_exchange(
         &self,
         current: <Self as AtomicInt>::Prim,
@@ -228,15 +221,6 @@ macro_rules! impl_atomic_int {
 
             fn swap(&self, val: $prim, order: Ordering) -> $prim {
                 self.swap(val, order)
-            }
-
-            fn compare_and_swap(
-                &self,
-                current: $prim,
-                new: $prim,
-                ordering: Ordering
-            ) -> $prim {
-                self.compare_and_swap(current, new, ordering)
             }
 
             fn compare_exchange(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,17 +14,17 @@ use std::ops::{
 pub trait AtomicInt : Default + Send + Sync + RefUnwindSafe + UnwindSafe {
     type Prim
         : Copy + Debug + Display + Eq + Hash + Ord + Sized
-        + Add + AddAssign
-        + BitAnd + BitAndAssign
-        + BitOr + BitOrAssign
-        + BitXor + BitXorAssign
-        + Div + DivAssign
-        + Mul + MulAssign
-        + Not
-        + Rem + RemAssign
-        + Shl + ShlAssign
-        + Shr + ShrAssign
-        + Sub + SubAssign;
+        + Add<Output = <Self as AtomicInt>::Prim> + AddAssign
+        + BitAnd<Output = <Self as AtomicInt>::Prim> + BitAndAssign
+        + BitOr<Output = <Self as AtomicInt>::Prim> + BitOrAssign
+        + BitXor<Output = <Self as AtomicInt>::Prim> + BitXorAssign
+        + Div<Output = <Self as AtomicInt>::Prim> + DivAssign
+        + Mul<Output = <Self as AtomicInt>::Prim> + MulAssign
+        + Not<Output = <Self as AtomicInt>::Prim>
+        + Rem<Output = <Self as AtomicInt>::Prim> + RemAssign
+        + Shl<Output = <Self as AtomicInt>::Prim> + ShlAssign
+        + Shr<Output = <Self as AtomicInt>::Prim> + ShrAssign
+        + Sub<Output = <Self as AtomicInt>::Prim> + SubAssign;
 
     const ZERO: <Self as AtomicInt>::Prim;
     const ONE: <Self as AtomicInt>::Prim;
@@ -262,3 +262,28 @@ impl_atomic_int!(atomic::AtomicI16 = i16);
 impl_atomic_int!(atomic::AtomicI32 = i32);
 impl_atomic_int!(atomic::AtomicI64 = i64);
 impl_atomic_int!(atomic::AtomicIsize = isize);
+
+#[cfg(test)]
+mod test {
+    use std::sync::atomic::AtomicU8;
+    use super::*;
+
+    #[test]
+    fn test_fetch_update() {
+        fn incr<T: AtomicInt>(value: &T) -> Result<<T as AtomicInt>::Prim, <T as AtomicInt>::Prim> {
+            value.fetch_update(
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+                |i| Some(if i == T::MAX { T::MIN } else { i + T::ONE })
+            )
+        }
+
+        let value = AtomicU8::new(0);
+        assert_eq!(incr(&value), Ok(0));
+        assert_eq!(incr(&value), Ok(1));
+
+        let value = AtomicU8::new(255);
+        assert_eq!(incr(&value), Ok(255));
+        assert_eq!(incr(&value), Ok(0));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,12 @@ pub trait AtomicInt : Default + Send + Sync + RefUnwindSafe + UnwindSafe {
         + Shr + ShrAssign
         + Sub + SubAssign;
 
+    const ZERO: <Self as AtomicInt>::Prim;
+    const ONE: <Self as AtomicInt>::Prim;
+
+    const MIN: <Self as AtomicInt>::Prim;
+    const MAX: <Self as AtomicInt>::Prim;
+
     fn new(val: <Self as AtomicInt>::Prim) -> Self;
 
     fn fetch_add(
@@ -116,6 +122,12 @@ pub trait AtomicInt : Default + Send + Sync + RefUnwindSafe + UnwindSafe {
 macro_rules! impl_atomic_int {
     ($atomic:ty = $prim:ty) => {
         impl AtomicInt for $atomic {
+            const ZERO: $prim = 0;
+            const ONE: $prim = 1;
+
+            const MIN: $prim = <$prim>::MIN;
+            const MAX: $prim = <$prim>::MAX;
+
             type Prim = $prim;
 
             fn new(val: $prim) -> Self {


### PR DESCRIPTION
## Purpose
Improve compatibility with recent Rust versions and make various usability improvements.

## Changes
- Remove redundant `nightly` feature for fetch_min, fetch_max and fetch_update
- Define ZERO, ONE, MIN and MAX
- Remove deprecated compare_and_swap() function
- Override Output of primitive traits

## Checklist
- [x] Self-review has been completed
- [x] Changes are complete and ready for review
- [x] Changes are covered by existing or new tests